### PR TITLE
Potential fix for code scanning alert no. 3: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/reljicd/config/SpringSecurityConfig.java
+++ b/src/main/java/com/reljicd/config/SpringSecurityConfig.java
@@ -56,7 +56,8 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
-        http.csrf().disable()
+        http.csrf()
+                .and()
                 .authorizeRequests()
                 .antMatchers("/home", "/registration", "/error", "/h2-console/**").permitAll()
                 .anyRequest().authenticated()


### PR DESCRIPTION
Potential fix for [https://github.com/VinayC0807/Ekart/security/code-scanning/3](https://github.com/VinayC0807/Ekart/security/code-scanning/3)

To fix the issue, CSRF protection should be re-enabled by removing the `http.csrf().disable()` call. This ensures that the application is protected against CSRF attacks. If there are specific endpoints that need to bypass CSRF protection (e.g., APIs), they can be explicitly excluded using Spring Security's `csrf().ignoringAntMatchers()` method.

The changes will be made in the `configure(HttpSecurity http)` method of the `SpringSecurityConfig` class. The `http.csrf().disable()` line will be removed, and CSRF protection will be enabled by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
